### PR TITLE
Backend Refresh

### DIFF
--- a/SP23.P03.Web/Controllers/TripsController.cs
+++ b/SP23.P03.Web/Controllers/TripsController.cs
@@ -50,16 +50,23 @@ public class TripsController : ControllerBase
     [Authorize(Roles = RoleNames.Admin)]
     public ActionResult<TripDto> CreateTrip([FromBody] CreateTripDto dto)
     {
-        if (InvalidCreateTripDto(dto))
+        var train = trains.FirstOrDefault(x => x.Id == dto.TrainId);
+        var fromStation = stations.FirstOrDefault(x => x.Id == dto.FromStationId);
+        var toStation = stations.FirstOrDefault(x => x.Id == dto.ToStationId);
+
+        if (InvalidCreateTripDto(dto)
+            || train == null
+            || fromStation == null
+            || toStation == null)
         {
             return BadRequest();
         }
 
         var createdTrip = new Trip
         {
-            TrainId = dto.TrainId,
-            FromStationId = dto.FromStationId,
-            ToStationId = dto.ToStationId,
+            Train = train,
+            FromStation = fromStation,
+            ToStation = toStation,
             Departure = dto.Departure,
             Arrival = dto.Arrival,
             BasePrice = dto.BasePrice
@@ -93,14 +100,21 @@ public class TripsController : ControllerBase
             return NotFound();
         }
 
-        if (InvalidCreateTripDto(dto))
+        var train = trains.FirstOrDefault(x => x.Id == dto.TrainId);
+        var fromStation = stations.FirstOrDefault(x => x.Id == dto.FromStationId);
+        var toStation = stations.FirstOrDefault(x => x.Id == dto.ToStationId);
+
+        if (InvalidCreateTripDto(dto)
+            || train == null
+            || fromStation == null
+            || toStation == null)
         {
             return BadRequest();
         }
 
-        trip.TrainId = dto.TrainId;
-        trip.FromStationId = dto.FromStationId;
-        trip.ToStationId = dto.ToStationId;
+        trip.Train = train;
+        trip.FromStation = fromStation;
+        trip.ToStation = toStation;
         trip.Departure = dto.Departure;
         trip.Arrival = dto.Arrival;
         trip.BasePrice = dto.BasePrice;
@@ -138,17 +152,11 @@ public class TripsController : ControllerBase
         return Ok();
     }
 
-    private bool InvalidCreateTripDto(CreateTripDto dto)
+    private static bool InvalidCreateTripDto(CreateTripDto dto)
     {
         bool isInvalid = false;
-        var train = trains.FirstOrDefault(x => x.Id == dto.TrainId);
-        var fromStation = stations.FirstOrDefault(x => x.Id == dto.FromStationId);
-        var toStation = stations.FirstOrDefault(x => x.Id == dto.ToStationId);
 
-        if (train == null ||
-            fromStation == null ||
-            toStation == null ||
-            (dto.FromStationId == dto.ToStationId) ||
+        if (dto.FromStationId == dto.ToStationId ||
             dto.Arrival.CompareTo(dto.Departure) <= 0 ||
             dto.BasePrice < 0) 
         {

--- a/SP23.P03.Web/Controllers/TripsController.cs
+++ b/SP23.P03.Web/Controllers/TripsController.cs
@@ -79,8 +79,20 @@ public class TripsController : ControllerBase
         {
             Id = createdTrip.Id,
             TrainId = createdTrip.TrainId,
-            FromStationId = createdTrip.FromStationId,
-            ToStationId = createdTrip.ToStationId,
+            FromStation = new TrainStationDto
+            {
+                Id = createdTrip.FromStation.Id,
+                Name = createdTrip.FromStation.Name,
+                Address = createdTrip.FromStation.Address,
+                ManagerId = createdTrip.FromStation.ManagerId,
+            },
+            ToStation = new TrainStationDto
+            {
+                Id = createdTrip.ToStation.Id,
+                Name = createdTrip.ToStation.Name,
+                Address = createdTrip.ToStation.Address,
+                ManagerId = createdTrip.ToStation.ManagerId,
+            },
             Departure = createdTrip.Departure,
             Arrival = createdTrip.Arrival,
             BasePrice = createdTrip.BasePrice
@@ -125,8 +137,20 @@ public class TripsController : ControllerBase
         {
             Id = trip.Id,
             TrainId = trip.TrainId,
-            FromStationId = trip.FromStationId,
-            ToStationId = trip.ToStationId,
+            FromStation = new TrainStationDto
+            {
+                Id = trip.FromStation.Id,
+                Name = trip.FromStation.Name,
+                Address = trip.FromStation.Address,
+                ManagerId = trip.FromStation.ManagerId,
+            },
+            ToStation = new TrainStationDto
+            {
+                Id = trip.ToStation.Id,
+                Name = trip.ToStation.Name,
+                Address = trip.ToStation.Address,
+                ManagerId = trip.ToStation.ManagerId,
+            },
             Departure = trip.Departure,
             Arrival = trip.Arrival,
             BasePrice = trip.BasePrice,
@@ -173,8 +197,20 @@ public class TripsController : ControllerBase
             {
                 Id = x.Id,
                 TrainId = x.TrainId,
-                FromStationId = x.FromStationId,
-                ToStationId = x.ToStationId,
+                FromStation = new TrainStationDto
+                {
+                    Id = x.FromStation.Id,
+                    Name = x.FromStation.Name,
+                    Address = x.FromStation.Address,
+                    ManagerId = x.FromStation.ManagerId,
+                },
+                ToStation = new TrainStationDto
+                {
+                    Id = x.ToStation.Id,
+                    Name = x.ToStation.Name,
+                    Address = x.ToStation.Address,
+                    ManagerId = x.ToStation.ManagerId,
+                },
                 Departure = x.Departure,
                 Arrival = x.Arrival,
                 BasePrice = x.BasePrice

--- a/SP23.P03.Web/Data/SeedHelper.cs
+++ b/SP23.P03.Web/Data/SeedHelper.cs
@@ -236,27 +236,27 @@ public static class SeedHelper
         trips.AddRange(
             new Trip
             {
-                TrainId = hammondTrain.Id,
-                FromStationId = hammondStation.Id,
-                ToStationId = slidellStation.Id,
+                Train = hammondTrain,
+                FromStation = hammondStation,
+                ToStation = slidellStation,
                 Departure = new DateTimeOffset(2023, 03, 13, 13, 00, 00, offset),
                 Arrival = new DateTimeOffset(2023, 03, 13, 13, 30, 00, offset),
                 BasePrice = 35
             },
             new Trip
             {
-                TrainId = hammondTrain.Id,
-                FromStationId = slidellStation.Id,
-                ToStationId = nolaStation.Id,
+                Train = hammondTrain,
+                FromStation = slidellStation,
+                ToStation = nolaStation,
                 Departure = new DateTimeOffset(2023, 03, 13, 13, 45, 00, offset),
                 Arrival = new DateTimeOffset(2023, 03, 13, 13, 55, 00, offset),
                 BasePrice = 10
             },
             new Trip
             {
-                TrainId = hammondTrain.Id,
-                FromStationId = nolaStation.Id,
-                ToStationId = hammondStation.Id,
+                Train = hammondTrain,
+                FromStation = nolaStation,
+                ToStation = hammondStation,
                 Departure = new DateTimeOffset(2023, 03, 13, 14, 15, 00, offset),
                 Arrival = new DateTimeOffset(2023, 03, 13, 14, 35, 00, offset),
                 BasePrice = 30

--- a/SP23.P03.Web/Features/BoardingPasses/BoardingPassDto.cs
+++ b/SP23.P03.Web/Features/BoardingPasses/BoardingPassDto.cs
@@ -1,10 +1,13 @@
-﻿namespace SP23.P03.Web.Features.BoardingPasses;
+﻿using SP23.P03.Web.Features.Passengers;
+using SP23.P03.Web.Features.Trips;
+
+namespace SP23.P03.Web.Features.BoardingPasses;
 
 public class BoardingPassDto
 {
     public int Id { get; set; }
     public string Code { get; set; } = string.Empty;
     public int OwnerId { get; set; }
-    public int TripId { get; set; }
-    public ICollection<int> PassengerIds { get; set; } = new List<int>();
+    public required TripDto Trip { get; set; }
+    public ICollection<PassengerDto> Passengers { get; set; } = new List<PassengerDto>();
 }

--- a/SP23.P03.Web/Features/Passengers/Passenger.cs
+++ b/SP23.P03.Web/Features/Passengers/Passenger.cs
@@ -5,8 +5,8 @@ namespace SP23.P03.Web.Features.Passengers
 {
     public class Passenger
     {
-        public const int MaxChildAge = 10;
-        public const int MinElderAge = 70;
+        public const int MaxChildAge = 13;
+        public const int MinSeniorAge = 65;
         public int Id { get; set; }
         public int OwnerId { get; set; }
         public required virtual User Owner { get; set; }
@@ -22,7 +22,7 @@ namespace SP23.P03.Web.Features.Passengers
             get
             {
                 var age = Age;
-                return age <= MaxChildAge ? "Child" : age >= MinElderAge ? "Elder" : "Adult";
+                return age <= MaxChildAge ? "Child" : age >= MinSeniorAge ? "Senior" : "Adult";
             }
         }
     }

--- a/SP23.P03.Web/Features/Passengers/Passenger.cs
+++ b/SP23.P03.Web/Features/Passengers/Passenger.cs
@@ -9,7 +9,7 @@ namespace SP23.P03.Web.Features.Passengers
         public const int MinElderAge = 70;
         public int Id { get; set; }
         public int OwnerId { get; set; }
-        public virtual User Owner { get; set; }
+        public required virtual User Owner { get; set; }
         public string FirstName { get; set; } = string.Empty;
         public string LastName { get; set; } = string.Empty;
         public DateTimeOffset Birthday { get; set; }

--- a/SP23.P03.Web/Features/Trips/Trip.cs
+++ b/SP23.P03.Web/Features/Trips/Trip.cs
@@ -7,11 +7,11 @@ public class Trip
 {
     public int Id { get; set; }
     public int TrainId { get; set; }
-    public Train? Train { get; set; }
+    public required Train Train { get; set; }
     public int FromStationId { get; set; }
-    public TrainStation? FromStation { get; set; }
+    public required TrainStation FromStation { get; set; }
     public int ToStationId { get; set; }
-    public TrainStation? ToStation { get; set; }
+    public required TrainStation ToStation { get; set; }
     public DateTimeOffset Departure { get; set; }
     public DateTimeOffset Arrival { get; set; }
     public int BasePrice { get; set; }

--- a/SP23.P03.Web/Features/Trips/TripDto.cs
+++ b/SP23.P03.Web/Features/Trips/TripDto.cs
@@ -1,11 +1,13 @@
-﻿namespace SP23.P03.Web.Features.Trips
+﻿using SP23.P03.Web.Features.TrainStations;
+
+namespace SP23.P03.Web.Features.Trips
 {
     public class TripDto
     {
         public int Id { get; set; }
         public int TrainId { get; set; }
-        public int FromStationId { get; set; }
-        public int ToStationId { get; set; }
+        public required TrainStationDto FromStation { get; set; }
+        public required TrainStationDto ToStation { get; set; }
         public DateTimeOffset Departure { get; set; }
         public DateTimeOffset Arrival { get; set; }
         public int BasePrice { get; set; }


### PR DESCRIPTION
1. 91ba518b23eb5641c8aeed0d65bedce99248d58b Sets some navigational properties to be required instead of nullable. This is generally a better approach for entity relationships that are required (unlike, say, the Manager property of a train station)
2. a27e9c48537ed996db8b1455cc644db8baad8eaf Renamed Elders to Seniors, increased max age for children from 10 to 13, decreased min age for seniors from 70 to 65
3. d3a89a42b8f4d2483a13eaa71dd9334f324430e1 TripDtos now contain the full TrainStationDto for the FromStation and ToStation, instead of just their ids
4. 85db5b0f5c2279a113029a215a4dd9e7241e5fcb BoardingPassDtos now contain the TripDto for the trip and PassengerDtos for the passengers, instead of just ids