### PR TITLE
Route Planning uses query params instead of route params

### DIFF
--- a/SP23.P03.Web/ClientApp/src/components/RoutePlanner/RoutePlanner.tsx
+++ b/SP23.P03.Web/ClientApp/src/components/RoutePlanner/RoutePlanner.tsx
@@ -1,16 +1,25 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Segment, Grid, Divider, Icon } from 'semantic-ui-react';
-import { routes } from '../../constants/routeconfig';
 import './RoutePlanner.css';
 import { StationSelection } from '../StationSelection';
+import { RoutePlanningQuery, navigateToRoutePlanning } from '../../helpers/navigation';
 
 const RoutePlanner: React.FC = () => {
     const navigate = useNavigate();
 
-    const navigateToRoutePlanning = () => {
-        navigate(routes.route_planning);
+    const onSubmit = (query: RoutePlanningQuery) => {
+        navigateToRoutePlanning(navigate, query);
     };
+
+    const EXAMPLE_ROUTE_PLANNING_QUERY = { 
+        fromStationId: 1,
+        toStationId: 2,
+        departure: "2023-04-01",
+        arrival: "2023-07-01",
+        travelClass: "Coach",
+    }; // This is an example route planning query since we don't have a Form for this component yet
+
     return (
         <div className="route-planner">
             <Segment padded raised className="resizing">
@@ -43,7 +52,9 @@ const RoutePlanner: React.FC = () => {
 
                     <Grid.Row>
                         <div className="btn-center">
-                            <button className="btn-styling" onClick={navigateToRoutePlanning}>
+                            <button className="btn-styling" onClick={
+                                () => onSubmit(EXAMPLE_ROUTE_PLANNING_QUERY)
+                            }>
                                 Book Now!
                             </button>
                         </div>

--- a/SP23.P03.Web/ClientApp/src/constants/routeconfig.tsx
+++ b/SP23.P03.Web/ClientApp/src/constants/routeconfig.tsx
@@ -4,5 +4,5 @@
 
 export const routes = {
     home : '/',
-    route_planning : '/route-planning/*'
+    route_planning : '/route-planning'
   }

--- a/SP23.P03.Web/ClientApp/src/helpers/navigation.tsx
+++ b/SP23.P03.Web/ClientApp/src/helpers/navigation.tsx
@@ -1,0 +1,14 @@
+import { NavigateFunction } from "react-router-dom";
+import { routes } from "../constants/routeconfig";
+
+export type RoutePlanningQuery = {
+    fromStationId: string | number;
+    toStationId: string | number;
+    departure: string;
+    arrival: string;
+    travelClass?: string;
+}
+
+export const navigateToRoutePlanning = (navigate: NavigateFunction, { fromStationId, toStationId, departure, arrival, travelClass }: RoutePlanningQuery) => {
+    navigate(`${routes.route_planning}?fromStation=${fromStationId}&toStation=${toStationId}&departure=${departure}&arrival=${arrival}&travelClass=${travelClass ?? "Coach"}`);
+}

--- a/SP23.P03.Web/ClientApp/src/hooks/api/useStation.tsx
+++ b/SP23.P03.Web/ClientApp/src/hooks/api/useStation.tsx
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { useEffect, useState } from 'react';
 import { TrainStationDto } from '../../types/types';
 
-const useStation = (stationId?: string | number) => {
+const useStation = (stationId?: string | number | null) => {
     const [station, setStation] = useState<TrainStationDto>();
 
     useEffect(() => {

--- a/SP23.P03.Web/ClientApp/src/hooks/api/useTripRoutes.tsx
+++ b/SP23.P03.Web/ClientApp/src/hooks/api/useTripRoutes.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import { TripWithCapacityDto } from '../../types/types';
 
 const fetchTripRoutes = (cb: (tripRoutes: TripWithCapacityDto[][]) => void, fromStationId: string, toStationId: string, departure: string, arrival: string, travelClass: string) =>
-    axios.get<TripWithCapacityDto[][]>(`/api/trips/search/${fromStationId}/${toStationId}/${departure}/${arrival}/${travelClass}`)
+    axios.get<TripWithCapacityDto[][]>(`/api/trips/search?fromStationId=${fromStationId}&toStationId=${toStationId}&departure=${departure}&arrival=${arrival}&travelClass=${travelClass}`)
         .then((response) => cb(response.data))
         .catch((error) => {
             if(axios.isAxiosError(error) && error.response?.status === 404){

--- a/SP23.P03.Web/ClientApp/src/pages/RoutePlanning/RouteListing.tsx
+++ b/SP23.P03.Web/ClientApp/src/pages/RoutePlanning/RouteListing.tsx
@@ -1,5 +1,4 @@
 import React from "react"
-import { PathMatch } from "react-router-dom";
 import { Grid, Header, Icon, Segment } from "semantic-ui-react";
 import useTripRoutes from "../../hooks/api/useTripRoutes";
 import { TripWithCapacityDto } from "../../types/types";
@@ -10,11 +9,16 @@ import { getTravelClassCapacity, getTravelClassPrice } from "../../helpers/trave
 import PurchaseBoardingPassModal from "./PurchaseBoardingPassModal";
 
 
-type RouteListingProps = { pathMatch: PathMatch<"fromStationId" | "toStationId" | "departure" | "arrival" | "travelClass"> };
+type RouteListingProps = { searchParams: URLSearchParams };
 
 const RouteListing: React.FC<RouteListingProps> = (props) => {
-    const { pathMatch } = props;
-    const { fromStationId, toStationId, departure, arrival, travelClass } = pathMatch.params;
+    const { searchParams } = props;
+
+    const fromStationId = searchParams.get("fromStation");
+    const toStationId = searchParams.get("toStation");
+    const departure = searchParams.get("departure");
+    const arrival = searchParams.get("arrival");
+    const travelClass = searchParams.get("travelClass") ?? "Coach";
 
     const tripRoutes = useTripRoutes(fromStationId ?? "", toStationId ?? "", departure ?? "", arrival ?? "", travelClass ?? "");
 

--- a/SP23.P03.Web/ClientApp/src/pages/RoutePlanning/RoutePlanning.tsx
+++ b/SP23.P03.Web/ClientApp/src/pages/RoutePlanning/RoutePlanning.tsx
@@ -1,12 +1,17 @@
 import React from "react";
-import { useMatch } from "react-router-dom";
+import { useSearchParams } from "react-router-dom";
 import { Divider } from "semantic-ui-react";
 import RoutePlanner from "../../components/RoutePlanner/RoutePlanner";
 import RouteListing from "./RouteListing";
 import './RoutePlanning.css';
 
 export function RoutePlanning(): React.ReactElement {
-    const pathMatch = useMatch(`/route-planning/:fromStationId/:toStationId/:departure/:arrival/:travelClass`);
+    const [searchParams] = useSearchParams();
+
+    const validSearch = searchParams.has("fromStation") &&
+                        searchParams.has("toStation") &&
+                        searchParams.has("departure") &&
+                        searchParams.has("arrival");
 
     return (
         <div>
@@ -15,7 +20,7 @@ export function RoutePlanning(): React.ReactElement {
                 <Divider />
             </div>
             <div>
-                {pathMatch && <RouteListing pathMatch={pathMatch} />}
+                {validSearch && <RouteListing searchParams={searchParams} />}
             </div>
         </div>
     );

--- a/SP23.P03.Web/Controllers/TripsController.cs
+++ b/SP23.P03.Web/Controllers/TripsController.cs
@@ -48,10 +48,11 @@ public class TripsController : ControllerBase
     }
 
     [HttpGet]
-    [Route("search/{fromStationId}/{toStationId}/{departure}/{arrival}/{travelClass}")]
-    public ActionResult<IEnumerable<IEnumerable<TripWithCapacityDto>>> GetRoute(int fromStationId, int toStationId,
-                                                                    DateTimeOffset departure, DateTimeOffset arrival,
-                                                                    string travelClass)
+    [Route("search")]
+    public ActionResult<IEnumerable<IEnumerable<TripWithCapacityDto>>> GetRoute(
+        [FromQuery] int fromStationId, [FromQuery] int toStationId,
+        [FromQuery] DateTimeOffset departure, [FromQuery] DateTimeOffset arrival,
+        [FromQuery] string travelClass = "Coach")
     {
         if (!(Enum.TryParse(travelClass, true, out TravelClass travelClassEnum) && Enum.IsDefined(travelClassEnum)))
         {


### PR DESCRIPTION
This changes how parameters are passed to the route planning page and requests to the `api/trips/search` endpoint.

Before, a URL for the route planning page might look like this:
```
https://localhost:7031/route-planning/1/2/2023-04-01/2023-07-01/Coach
```
Now, it looks like this:
```
https://localhost:7031/route-planning?fromStation=1&toStation=2&departure=2023-04-01&arrival=2023-07-01&travelClass=Coach
```
It is a bit more verbose but makes more sense given that it is practically a search query.

**Additionally,** a new helper method has been added that will automatically navigate you to the route planning page with a given query:
```tsx
navigateToRoutePlanning(navigate: NavigateFunction, { fromStationId, toStationId, departure, arrival, travelClass }: RoutePlanningQuery)
```
This has been added to the `RoutePlanner` component (#28) along with an example query object.